### PR TITLE
Makefile updates regular expressions when building

### DIFF
--- a/regex/Makefile
+++ b/regex/Makefile
@@ -1,12 +1,16 @@
 # Compiles all multi-regexes.
 
-.PHONY: all clean
+.PHONY: all inject clean
 OBJECTS = input session
 
-all: $(OBJECTS)
+all: $(OBJECTS) inject
 
 %:
 	python sub_regex.py $@.regex $@.out
+
+inject:
+	python update_regex.py regex input.out ../js/CourseParser.js
+	python update_regex.py subCourseRegex session.out ../js/CourseParser.js
 
 clean:
 	rm *.out

--- a/regex/update_regex.py
+++ b/regex/update_regex.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+from __future__ import with_statement
+import re, sys
+
+if __name__ == "__main__":
+    if len(sys.argv) < 4:
+        print("Usage: update_regex.py field-name input-file output-file")
+        exit(1)
+
+    field = sys.argv[1]
+
+    with open(sys.argv[2], 'r') as fh:
+        to_replace = fh.read()
+
+    with open(sys.argv[3], 'r') as fh:
+        output_text = fh.read()
+
+    to_replace = to_replace.replace("\\n", "\\\\n").strip()
+
+    output_text = \
+        re.sub(r"this\.%s\s*=\s*\/.*\/g;" % re.escape(field), \
+               "this.%s = /%s/g;" % (field, to_replace, \
+               output_text)
+     
+    with open(sys.argv[3], 'w+') as fh:
+        fh.write(output_text)
+
+


### PR DESCRIPTION
Invokes a Python script that replaces the two fields specified directly in the `Makefile` based on the result of the regular expressions in the `regex/` directory.

Fixes #38.
