### PR TITLE
Fixed disparity between different browser defaults

### DIFF
--- a/css/normalize.css
+++ b/css/normalize.css
@@ -1,0 +1,427 @@
+/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
+
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS text size adjust after orientation change, without disabling
+ *    user zoom.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/**
+ * Remove default margin.
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
+   ========================================================================== */
+
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
+ */
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * Improve readability when focused and also mouse hovered in all browsers.
+ */
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+
+b,
+strong {
+  font-weight: bold;
+}
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Address styling not present in IE 8/9.
+ */
+
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+
+img {
+  border: 0;
+}
+
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * Address differences between Firefox and other browsers.
+ */
+
+hr {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 0;
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit; /* 1 */
+  font: inherit; /* 2 */
+  margin: 0; /* 3 */
+}
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+
+button,
+select {
+  text-transform: none;
+}
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+
+button,
+html input[type="button"], /* 1 */
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
+}
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+input {
+  line-height: normal;
+}
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
+ *    (include `-moz` to future-proof).
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box; /* 2 */
+  box-sizing: content-box;
+}
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+
+optgroup {
+  font-weight: bold;
+}
+
+/* Tables
+   ========================================================================== */
+
+/**
+ * Remove most spacing between table cells.
+ */
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -16,15 +16,12 @@ body {
     max-width: 820px;
 }
 p {
-    margin: 0 0 10px 0;
+    margin: 0 0 10px;
 }
 a {
     color: #4895F4;
     text-decoration: none;
     transition: color .15s;
-}
-br {
-    margin-bottom: 20px;
 }
 a:hover,
 a:focus,
@@ -33,7 +30,7 @@ a:active {
     border-bottom: 1px dotted #2f2f2f;
 }
 textarea {
-    margin-bottom: 25px;
+    margin: 0 auto 25px auto;
     height: 85px;
     width: 500px;
     border-radius: 3px;
@@ -42,6 +39,7 @@ textarea {
     font-size: 16px;
     resize: none;
     overflow: auto;
+    color: #6C6C6C;
 }
 div.centered {
     text-align: center;
@@ -79,10 +77,11 @@ div.centered table {
 }
 .pure-table td {
     height: 20px;
+    padding: 2px 0;
 }
 .pure-table th {
-    height: 35px;
-    padding-bottom: 15px;
+    padding: 10px 0;
+    text-align: center;
 }
 .rspan{
     background-color: rgba(0, 0, 0, .3);
@@ -108,9 +107,8 @@ there's a rowspan on the first cell. Case added to the tests. issue#432 */
     padding: 25px;
 }
 .jumbotron {
-    margin: 0px 0;
     text-align: center;
-    transition: width .5s, height .5s, margin .5s, padding .5s
+    transition: width .5s, height .5s, margin .5s, padding .5s;
 }
 .jumbotron h1 {
     color: #f8f8f8;
@@ -118,28 +116,17 @@ there's a rowspan on the first cell. Case added to the tests. issue#432 */
     font-size: 50px;
     font-weight: 700;
     line-height: 1;
-    margin: 15px 0;
+    margin: 15px 0 5px 0;
     cursor: default;
-    text-rendering: optimizelegibility
+    text-rendering: optimizelegibility;
 }
 .jumbotron .lead {
     font-size: 21px;
     font-weight: 200;
-    line-height: 20px;
-    height: 20px;
+    line-height: 30px;
     margin-bottom: 40px;
-    transition: font-size .5s
-}
-.jumbotron .form-group{
-  display: block;
-  margin: 0px 0;
-  width: 200px;
-  height: 50px;
-  font-family: sans-serif;
-  font-size: 18px;
-  appearance: none;
-  box-shadow: none;
-  border-radius: none;
+    transition: font-size .5s;
+    cursor: default;
 }
 .btn {
     background: none;
@@ -173,12 +160,12 @@ there's a rowspan on the first cell. Case added to the tests. issue#432 */
 .alert-error {
     background-color: #F2DEDE;
     border-color: #EED3D7;
-    color: #AA4342
+    color: #AA4342;
 }
 .alert-info {
     background-color: #E5E5E5;
     border-color: #EAEAEA;
-    color: #6C6C6C
+    color: #6C6C6C;
 }
 nav>ul,
 nav a {
@@ -187,22 +174,22 @@ nav a {
     margin: 0;
     margin-bottom: 75px;
     padding: 0;
-    text-align: center
+    text-align: center;
 }
 nav>ul>li {
     display: inline-block;
     margin: 0;
     padding: 0;
-    cursor: default
+    cursor: default;
 }
 nav>ul>li:after {
     content: "|";
     margin: 0 8px;
-    opacity: .3
+    opacity: .3;
 }
 nav>ul>li:last-child:after {
     content: "";
-    margin: 0
+    margin: 0;
 }
 section {
     margin-bottom: 40px;
@@ -222,7 +209,7 @@ only screen and (max-width: 400px) {
         margin: 0 10px 0 10px;
     }
     .jumbotron {
-        margin: 0px 0px 20px 0px;
+        margin: 0 0 20px 0;
     }
     .jumbotron .lead {
         font-size: 18px;
@@ -242,10 +229,10 @@ only screen and (max-width: 400px) {
         padding: 10px 0;
     }
     nav ul li {
-        margin: 0px 0px 12px 0px;
+        margin: 0 0 12px 0;
     }
     nav a {
-        padding: 15px 5px 0px 5px;
+        padding: 15px 5px 0 5px;
     }
 
 }

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
         <title>UCR Schedule Visualizer</title>
         <link rel="shortcut icon" href="img/ucr-icon.png" type="image/png">
+        <link rel="stylesheet" href="css/normalize.css">
         <link rel="stylesheet" href="css/style.css">
         <link rel="stylesheet" href="css/bs-popover.css">
         <script type="text/javascript" src="js/jquery.min.js"></script>


### PR DESCRIPTION
Issue #56 

Different browsers have different css style defaults.

We're now using [normalize.css](https://necolas.github.io/normalize.css/) to make our style look similar on most modern browsers. 

A bit of design polishing and bug fixing was done too. 
