### PR TITLE
Added safari compatability

### DIFF
--- a/js/Schedule.js
+++ b/js/Schedule.js
@@ -282,7 +282,7 @@ function Schedule(courseList) {
                 " <br><strong>Location:</strong> " + location,
                 html: true,
                 animation: true,
-                trigger: "focus"
+                trigger: "click"
             });
         }
     };


### PR DESCRIPTION
Issue #35 

More information about the compatibility and reasoning behind our solution is written in issue #35 . 

Instead of "focus" to create and dismiss popovers, it is "click" to create and dismiss popovers. 
